### PR TITLE
Renamed markOrderComplete to markItemComplete

### DIFF
--- a/src/FOHController.java
+++ b/src/FOHController.java
@@ -14,7 +14,7 @@ public abstract class FOHController implements FOHManagementInterface, FOHKitche
     }
 
     @Override
-    public void markOrderComplete(int orderID) {
+    public void markItemComplete(int orderID, int itemID) {
     }
 
     @Override

--- a/src/FOHKitchenInterface.java
+++ b/src/FOHKitchenInterface.java
@@ -1,7 +1,7 @@
 public interface FOHKitchenInterface {
 
     // Method for the kitchen to indicate an order is complete and appropriately notify for serving
-    void markOrderComplete(int orderID);
+    void markItemComplete(int orderID, int itemID);
 
     // Method to notify the FoH System which menu items to display as no longer available to order
     void markItemUnavailable(int itemID);


### PR DESCRIPTION
Enables individual items from an order to be marked as completed, rather than requiring an entire order completed at once. Some may order starters, main etc all at once.